### PR TITLE
feature (add usageInfo): add property usageInfo to CreativeWork

### DIFF
--- a/ontology/ontology.json
+++ b/ontology/ontology.json
@@ -24,7 +24,7 @@
       "rdfs:label": "RESCS SHACL Shapes",
       "owl:versionInfo": {
         "@type": "xsd:date",
-        "@value": "2022-01-10"
+        "@value": "2024-05-28"
       }
     },
     {

--- a/shapes/creativework/schema.json
+++ b/shapes/creativework/schema.json
@@ -82,6 +82,13 @@
               "maxCount": 1
             },
             {
+              "path": "schema:usageInfo",
+              "name": "usageInfo",
+              "description": "The schema.org [[usageInfo]] property indicates further information about a [[CreativeWork]]. This property is applicable both to works that are freely available and to those that require payment or other transactions. It can reference additional information e.g. community expectations on preferred linking and citation conventions, as well as purchasing details. For something that can be commercially licensed, usageInfo can provide detailed, resource-specific information about licensing options. This property can be used alongside the license property which indicates license(s) applicable to some piece of content. The usageInfo property can provide information about other licensing options, e.g. acquiring commercial usage rights for an image that is also available under non-commercial creative commons licenses.",
+              "nodeKind": "sh:IRI",
+              "maxCount": 1
+            },
+            {
               "path": "schema:copyrightHolder",
               "name": "copyrightHolder",
               "description": "The party holding the legal copyright to the CreativeWork.",

--- a/test/creativework/creativework.json
+++ b/test/creativework/creativework.json
@@ -130,5 +130,9 @@
     "@id": "http://www.example.com/12",
     "@type": "Place",
     "name": "New York"
+  },
+  "usageInfo": [{
+    "@id": "https://creativecommons.org/publicdomain/zero/1.0/deed.en"
   }
+  ]
 }


### PR DESCRIPTION
This PR adds the property [schema:usageInfo](https://schema.org/usageInfo) to schema:CreativeWork with max. card. 1. 

See https://github.com/Connectome-Implementation-Team/Project-Members-Proposals/issues/14#issuecomment-2134574648