### PR TITLE
refactor (parentOrganization): use paentOrganization

### DIFF
--- a/shapes/organization/schema.json
+++ b/shapes/organization/schema.json
@@ -77,9 +77,9 @@
               ]
             },
             {
-              "path": "schema:subOrganization",
-              "name": "subOrganization",
-              "description": "A relationship between two organizations where the first includes the second, e.g., as a subsidiary. See also: the more specific 'department' property.",
+              "path": "schema:parentOrganization",
+              "name": "parentOrganization",
+              "description": "The larger organization that this organization is a subOrganization of, if any.",
               "class": "schema:Organization",
               "nodeKind": "sh:IRI"
             },

--- a/test/archiveorganization/archiveorganization.json
+++ b/test/archiveorganization/archiveorganization.json
@@ -57,7 +57,7 @@
   "member": {
     "@id": "http://www.example.com/5"
   },
-  "subOrganization": {
+  "parentOrganization": {
     "@id": "http://www.example.com/7",
     "@type": "Organization",
     "name": "my suborg",

--- a/test/organization/bad_organization_keywords.json
+++ b/test/organization/bad_organization_keywords.json
@@ -57,7 +57,7 @@
   "member": {
     "@id": "http://www.example.com/5"
   },
-  "subOrganization": {
+  "parentOrganization": {
     "@id": "http://www.example.com/7",
     "@type": "Organization",
     "name": "my suborg",

--- a/test/organization/organization.json
+++ b/test/organization/organization.json
@@ -57,7 +57,7 @@
   "member": {
     "@id": "http://www.example.com/5"
   },
-  "subOrganization": {
+  "parentOrganization": {
     "@id": "http://www.example.com/7",
     "@type": "Organization",
     "name": "my suborg",


### PR DESCRIPTION
This PR substitutes `schema:subOrganization` for `schema:parentOrganization` to facilitate the embedding of both organizations in a document representing a `schema:ArchiveComponent`, see

```json
{
    "@id": "https://data.connectome.ch/patrinum/archivecomponent/170263",
    "@type": "ArchiveComponent",
    "abstract": "Photographies de Paris et Versailles.",
    "author": {
      "@id": "https://data.connectome.ch/patrinum/person/170263-unknown",
      "@type": "Person",
      "familyName": "unkown",
      "givenName": "unknown",
      "name": "unknown author"
    },
    "conditionsOfAccess": "Libre",
    "dateCreated": "1935-04-01",
    "dateModified": [
      "2023-12-29",
      "2024-10-07"
    ],
    "holdingArchive": {
      "@id": "https://data.connectome.ch/patrinum/archiveorganization/175548",
      "@type": "ArchiveOrganization",
      "name": "Service des Manuscrits",
      "parentOrganization": [
        {
          "@id": "https://data.connectome.ch/patrinum/archiveorganization/Bibliothèque%20cantonale%20et%20universitaire-Lausanne",
          "@type": "ArchiveOrganization",
          "name": "Bibliothèque cantonale et universitaire-Lausanne" 
        }
      ]
    },
    "identifier": "170263",
    "name": "France"
}

```